### PR TITLE
Bitwise & for compression flag check

### DIFF
--- a/src/previewbsa.cpp
+++ b/src/previewbsa.cpp
@@ -150,7 +150,7 @@ QWidget* PreviewBsa::genBsaPreview(const QString& fileName, const QSize&)
     // tr("Archive Format: %1 , Compression: %2 , File count: %3 , Version: %4 , "
     //    "Archive type: %5 , Archive flags: %6 , Contents flags: %7");
     infoString = infoString.arg(getFormat(arch.getType()))
-                     .arg((arch.getFlags() | 0x00000004) ? tr("yes") : tr("no"))
+                     .arg((arch.getFlags() & 0x00000004) ? tr("yes") : tr("no"))
                      .arg(m_Files.size())
                      .arg(getVersion(arch.getType()))
                      .arg(arch.getType())


### PR DESCRIPTION
Display "Compression: yes" only if the 0x4 flag is set.