### PR TITLE
Refactor loop to use QHash and ensure SimpleFileTreeModel destructor is called

### DIFF
--- a/src/previewbsa.cpp
+++ b/src/previewbsa.cpp
@@ -159,7 +159,7 @@ QWidget* PreviewBsa::genBsaPreview(const QString& fileName, const QSize&)
   layout->addWidget(infoLabel);
 
   QTreeView* view            = new QTreeView();
-  SimpleFileTreeModel* model = new SimpleFileTreeModel(m_Files);
+  SimpleFileTreeModel* model = new SimpleFileTreeModel(m_Files, view);
 
   view->setModel(model);
   layout->addWidget(view);

--- a/src/simplefiletreeitem.cpp
+++ b/src/simplefiletreeitem.cpp
@@ -18,9 +18,10 @@ SimpleFileTreeItem::~SimpleFileTreeItem()
   qDeleteAll(m_childItems);
 }
 
-void SimpleFileTreeItem::appendChild(SimpleFileTreeItem* item)
+void SimpleFileTreeItem::appendChild(const QString& name, SimpleFileTreeItem* item)
 {
   m_childItems.append(item);
+  m_childItemsByName.insert(name, item);
 }
 
 SimpleFileTreeItem* SimpleFileTreeItem::child(int row)
@@ -28,6 +29,11 @@ SimpleFileTreeItem* SimpleFileTreeItem::child(int row)
   if (row < 0 || row >= m_childItems.size())
     return nullptr;
   return m_childItems.at(row);
+}
+
+SimpleFileTreeItem* SimpleFileTreeItem::childByName(const QString& name)
+{
+  return m_childItemsByName.value(name);
 }
 
 QVector<SimpleFileTreeItem*> SimpleFileTreeItem::children()

--- a/src/simplefiletreeitem.h
+++ b/src/simplefiletreeitem.h
@@ -11,9 +11,10 @@ public:
                               SimpleFileTreeItem* parentItem = nullptr);
   ~SimpleFileTreeItem();
 
-  void appendChild(SimpleFileTreeItem* child);
+  void appendChild(const QString& name, SimpleFileTreeItem* child);
 
   SimpleFileTreeItem* child(int row);
+  SimpleFileTreeItem* childByName(const QString& name);
   QVector<SimpleFileTreeItem*> children();
   int childCount() const;
   int columnCount() const;
@@ -23,6 +24,7 @@ public:
 
 private:
   QVector<SimpleFileTreeItem*> m_childItems;
+  QHash<QString, SimpleFileTreeItem*> m_childItemsByName;
   QVector<QVariant> m_itemData;
   SimpleFileTreeItem* m_parentItem;
 };

--- a/src/simplefiletreemodel.cpp
+++ b/src/simplefiletreemodel.cpp
@@ -130,18 +130,10 @@ void SimpleFileTreeModel::setupModelData(const QStringList& lines,
     auto currentParent      = m_RootItem;
 
     for (int i = 0; i < lineEntries.count(); i++) {
-      QString currentEntryName         = lineEntries[i];
-      SimpleFileTreeItem* currentEntry = nullptr;
+      QString currentEntryName = lineEntries[i];
 
       // check if item was already added
-      if (currentParent->childCount() > 0) {
-        for (auto child : currentParent->children()) {
-          if (child->data(0).toString() == currentEntryName) {
-            currentEntry = child;
-            break;
-          }
-        }
-      }
+      SimpleFileTreeItem* currentEntry = currentParent->childByName(currentEntryName);
 
       // add tree item if not found
       if (currentEntry == nullptr) {
@@ -149,7 +141,7 @@ void SimpleFileTreeModel::setupModelData(const QStringList& lines,
         columnData.reserve(m_ColumnCount);
         columnData << currentEntryName;
         currentEntry = new SimpleFileTreeItem(columnData, currentParent);
-        currentParent->appendChild(currentEntry);
+        currentParent->appendChild(currentEntryName, currentEntry);
       }
 
       // as we go deeper into the path


### PR DESCRIPTION
This factors out a loop that is costly when a directory contains many children. It also passes a parent to the model so the destructor is called when the preview dialog is closed.